### PR TITLE
Fix: initialize variables xs, ys, and zs to prevent undefined behavior

### DIFF
--- a/tools/guv2plt/src/main.cc
+++ b/tools/guv2plt/src/main.cc
@@ -11,9 +11,9 @@ int main(int argc, char * argv[]) {
   string set_fname(char[]);
 
   int ch;
-  float xs, ys, zs;
-  string prog; 
-  
+  float xs = 0.0f, ys = 0.0f, zs = 0.0f;
+  string prog;
+
   while ((ch = getopt(argc, argv, "x:y:z:cv")) != -1) {
     switch (ch){
     case 'x':


### PR DESCRIPTION
# Summary
This PR fixes an issue where the variables `xs`, `ys`, and `zs` were not initialized, leading to undefined behavior when the command-line options `-x`, `-y`, and `-z` were not provided.
# Changes
The variables `xs`, `ys`, and `zs` are now initialized to 0.0f at their declaration.
```c++
float xs = 0.0f, ys = 0.0f, zs = 0.0f;
```
# Details
## Probrem
- In C++, variables are not guaranteed to be automatically initialized to zero.
- `xs`, `ys`, and `zs` were designed to be set by command-line options. If these options were not used, they retained undefined values from memory, potentially leading to unpredictable program output or incorrect calculations.
# Solution
Initializing `xs`, `ys`, and `zs` to 0.0f during declaration ensures they have a defined value (0.0f) even when the command-line options are not specified.
